### PR TITLE
Make static_variant count() usable at compile time

### DIFF
--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -351,7 +351,7 @@ namespace fc {
             return impl::storage_ops<0, Types...>::apply(_tag, storage, v);
         }
 
-        static int count() {
+        static constexpr int count() {
             return impl::type_info<Types...>::count;
         }
 


### PR DESCRIPTION
Required for GolosChain/golos#742